### PR TITLE
Fix issue #70: 検索ダイアログの変更

### DIFF
--- a/manager/app/components/dialog/SearchDialog.module.css
+++ b/manager/app/components/dialog/SearchDialog.module.css
@@ -1,0 +1,11 @@
+.searchDialogPaper {
+  background: #fff !important;
+  color: #171717 !important;
+}
+
+@media (prefers-color-scheme: dark) {
+  .searchDialogPaper {
+    background: #222 !important;
+    color: #ededed !important;
+  }
+}

--- a/manager/app/components/dialog/SearchDialog.tsx
+++ b/manager/app/components/dialog/SearchDialog.tsx
@@ -8,6 +8,8 @@ import CircularProgress from "@mui/material/CircularProgress";
 import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
 import { useState, useEffect, useRef } from "react";
+import styles from "./SearchDialog.module.css";
+
 
 interface SearchDialogProps {
     open: boolean;
@@ -177,7 +179,9 @@ export default function SearchDialog({
     };
 
     return (
-        <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
+        <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth
+            PaperProps={{ className: styles.searchDialogPaper }}
+        >
             <DialogTitle>検索</DialogTitle>
             <DialogContent>
                 <Box sx={{ mb: 2 }}>


### PR DESCRIPTION
This pull request fixes #70.

The changes introduce a new CSS module (SearchDialog.module.css) that explicitly sets the background and text color of the search dialog's Paper component. In light mode, the background is set to white (#fff) and text to dark (#171717), while in dark mode (using @media (prefers-color-scheme: dark)), the background is set to a dark gray (#222) and text to a light color (#ededed). The SearchDialog component is updated to apply this style to the Dialog's Paper via the PaperProps property. This ensures that the search dialog will have a visible and contrasting background and text color in both light and dark modes, preventing it from blending into the background in dark mode as described in the issue. Therefore, the issue is successfully resolved by these changes.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌