### PR TITLE
Fix issue #83: Search ダイアログのリストの横に追加ボタンの追加

### DIFF
--- a/manager/app/components/dialog/SearchDialog.tsx
+++ b/manager/app/components/dialog/SearchDialog.tsx
@@ -283,18 +283,28 @@ export default function SearchDialog({
                             </Typography>
                             <List sx={{ maxHeight: 300, overflow: 'auto', border: '1px solid #ddd', borderRadius: 1 }}>
                                 {searchResults.map((result) => (
-                                    <ListItem key={result.contentId} disablePadding>
-                                        <ListItemButton onClick={() => handleSelectResult(result)}>
-                                            <ListItemText
-                                                primary={result.title}
-                                                secondary={
-                                                    <Typography variant="caption" display="block">
-                                                        ID: {result.contentId}
-                                                    </Typography>
-                                                }
-                                            />
-                                        </ListItemButton>
-                                    </ListItem>
+                                    <Box key={result.contentId} sx={{ display: 'flex', alignItems: 'center' }}>
+                                        <ListItem disablePadding sx={{ flex: 1 }}>
+                                            <ListItemButton onClick={() => handleSelectResult(result)}>
+                                                <ListItemText
+                                                    primary={result.title}
+                                                    secondary={
+                                                        <Typography variant="caption" display="block">
+                                                            ID: {result.contentId}
+                                                        </Typography>
+                                                    }
+                                                />
+                                            </ListItemButton>
+                                        </ListItem>
+                                        <Button
+                                            variant="outlined"
+                                            size="small"
+                                            sx={{ ml: 1 }}
+                                            // onClick={...} // 実装は別途
+                                        >
+                                            追加
+                                        </Button>
+                                    </Box>
                                 ))}
                             </List>
                         </Box>


### PR DESCRIPTION
This pull request fixes #83.

The issue requested the addition of an "追加" (Add) button next to each item in the search dialog list, specifying that only the UI (the "shell") was needed and that the internal logic could be implemented separately. The changes in the patch wrap each list item and a new "追加" button in a flex container, placing the button to the right of each search result. The button is visually present, styled, and labeled as required, but its onClick handler is commented out, which aligns with the instruction to implement only the UI for now. Therefore, the issue has been successfully resolved as per the requirements.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌