### PR TITLE
Fix issue #84: Search ダイアログのリストの横に追加ボタンの実装

### DIFF
--- a/manager/app/components/dialog/SearchDialog.tsx
+++ b/manager/app/components/dialog/SearchDialog.tsx
@@ -89,6 +89,11 @@ export default function SearchDialog({
         }
     }, [open]);
 
+    // Handle add button click
+    const handleAdd = (result: SearchResult) => {
+        onRegister({ music_id: result.contentId, title: result.title });
+    }
+
     // Extract Music ID from URL
     const extractMusicIdFromUrl = (inputUrl: string): string | null => {
         if (!inputUrl) return null;
@@ -300,7 +305,7 @@ export default function SearchDialog({
                                             variant="outlined"
                                             size="small"
                                             sx={{ ml: 1 }}
-                                            // onClick={...} // 実装は別途
+                                            onClick={() => handleAdd(result)}
                                         >
                                             追加
                                         </Button>


### PR DESCRIPTION
This pull request adds functionality to the `SearchDialog` component to handle adding search results. The changes include implementing a new handler for the "Add" button and connecting this handler to the button's `onClick` event.

Functionality enhancements:

* [`manager/app/components/dialog/SearchDialog.tsx`](diffhunk://#diff-20e87f18f4802a463af256460c6ea676e907968c506fa5ebdab24fde95c8ab88R92-R96): Implemented the `handleAdd` function to register a search result with its `music_id` and `title`.
* [`manager/app/components/dialog/SearchDialog.tsx`](diffhunk://#diff-20e87f18f4802a463af256460c6ea676e907968c506fa5ebdab24fde95c8ab88L303-R308): Updated the "Add" button's `onClick` event to call the `handleAdd` function with the selected search result.