### PR TITLE
Fix issue #119: [Manager] 検索欄に削除ボタンを追加する

### DIFF
--- a/manager/app/components/auth/SignedInContent.tsx
+++ b/manager/app/components/auth/SignedInContent.tsx
@@ -371,6 +371,18 @@ export default function SignedInContent({ session }: { session: Session }) {
                                     fullWidth
                                     variant="outlined"
                                     sx={{ backgroundColor: "#fff" }}
+                                    InputProps={{
+                                        endAdornment: searchKeyword ? (
+                                            <IconButton
+                                                aria-label="clear search"
+                                                onClick={() => setSearchKeyword('')}
+                                                edge="end"
+                                                size="small"
+                                            >
+                                                <ClearIcon />
+                                            </IconButton>
+                                        ) : null,
+                                    }}
                                 />
                             </Box>
                             

--- a/manager/app/components/auth/SignedInContent.tsx
+++ b/manager/app/components/auth/SignedInContent.tsx
@@ -23,7 +23,9 @@ import {
   Select,
   MenuItem,
   Pagination,
+  IconButton,
 } from "@mui/material";
+import ClearIcon from '@mui/icons-material/Clear';
 import styles from "../../page.module.css";
 import EditDialog from "@/app/components/dialog/EditDialog";
 import DeleteDialog from "@/app/components/dialog/DeleteDialog";
@@ -372,10 +374,10 @@ export default function SignedInContent({ session }: { session: Session }) {
                                     variant="outlined"
                                     sx={{ backgroundColor: "#fff" }}
                                     InputProps={{
-                                        endAdornment: searchKeyword ? (
+                                        endAdornment: searchTerm ? (
                                             <IconButton
                                                 aria-label="clear search"
-                                                onClick={() => setSearchKeyword('')}
+                                                onClick={() => setSearchTerm('')}
                                                 edge="end"
                                                 size="small"
                                             >

--- a/manager/app/components/dialog/SearchDialog.tsx
+++ b/manager/app/components/dialog/SearchDialog.tsx
@@ -227,6 +227,59 @@ export default function SearchDialog({
 
                     {/* Search section */}
                     <Box sx={{ display: "flex", gap: 1, mb: 2 }}>
+                                                       <TextField
+                                                               label="ID"
+                                                               value={musicId}
+                                                               onChange={e => {
+                                                                       setMusicId(e.target.value);
+                                                                       handleFieldChange("music_id", e.target.value);
+                                                               }}
+                                                               fullWidth
+                                                               size="small"
+                                                               placeholder="例: sm12345678"
+                                                               InputProps={{
+                                                                       endAdornment: musicId ? (
+                                                                               <IconButton
+                                                                                       aria-label="clear id"
+                                                                                       onClick={() => {
+                                                                                               setMusicId("");
+                                                                                               handleFieldChange("music_id", "");
+                                                                                       }}
+                                                                                       edge="end"
+                                                                                       size="small"
+                                                                               >
+                                                                                               <ClearIcon />
+                                                                                       </IconButton>
+                                                                               ) : null,
+                                                               }} />
+
+                                                       <TextField
+                                                               label="タイトル"
+                                                               value={title}
+                                                               onChange={e => {
+                                                                       setTitle(e.target.value);
+                                                                       handleFieldChange("title", e.target.value);
+                                                               }}
+                                                               fullWidth
+                                                               size="small"
+                                                               placeholder="例: 初音ミクの歌"
+                                                               InputProps={{
+                                                                       endAdornment: title ? (
+                                                                               <IconButton
+                                                                                       aria-label="clear title"
+                                                                                       onClick={() => {
+                                                                                               setTitle("");
+                                                                                               handleFieldChange("title", "");
+                                                                                       }}
+                                                                                       edge="end"
+                                                                                       size="small"
+                                                                               >
+                                                                                               <ClearIcon />
+                                                                                       </IconButton>
+                                                                               ) : null,
+                                                               }} />
+
+
                         <TextField
                             label="検索キーワード"
                             value={searchKeyword}

--- a/manager/app/components/dialog/SearchDialog.tsx
+++ b/manager/app/components/dialog/SearchDialog.tsx
@@ -227,59 +227,6 @@ export default function SearchDialog({
 
                     {/* Search section */}
                     <Box sx={{ display: "flex", gap: 1, mb: 2 }}>
-                                                       <TextField
-                                                               label="ID"
-                                                               value={musicId}
-                                                               onChange={e => {
-                                                                       setMusicId(e.target.value);
-                                                                       handleFieldChange("music_id", e.target.value);
-                                                               }}
-                                                               fullWidth
-                                                               size="small"
-                                                               placeholder="例: sm12345678"
-                                                               InputProps={{
-                                                                       endAdornment: musicId ? (
-                                                                               <IconButton
-                                                                                       aria-label="clear id"
-                                                                                       onClick={() => {
-                                                                                               setMusicId("");
-                                                                                               handleFieldChange("music_id", "");
-                                                                                       }}
-                                                                                       edge="end"
-                                                                                       size="small"
-                                                                               >
-                                                                                               <ClearIcon />
-                                                                                       </IconButton>
-                                                                               ) : null,
-                                                               }} />
-
-                                                       <TextField
-                                                               label="タイトル"
-                                                               value={title}
-                                                               onChange={e => {
-                                                                       setTitle(e.target.value);
-                                                                       handleFieldChange("title", e.target.value);
-                                                               }}
-                                                               fullWidth
-                                                               size="small"
-                                                               placeholder="例: 初音ミクの歌"
-                                                               InputProps={{
-                                                                       endAdornment: title ? (
-                                                                               <IconButton
-                                                                                       aria-label="clear title"
-                                                                                       onClick={() => {
-                                                                                               setTitle("");
-                                                                                               handleFieldChange("title", "");
-                                                                                       }}
-                                                                                       edge="end"
-                                                                                       size="small"
-                                                                               >
-                                                                                               <ClearIcon />
-                                                                                       </IconButton>
-                                                                               ) : null,
-                                                               }} />
-
-
                         <TextField
                             label="検索キーワード"
                             value={searchKeyword}


### PR DESCRIPTION
This pull request enhances the `SearchDialog` component by adding two new input fields for filtering search results by "ID" and "タイトル" (Title). These fields include functionality for clearing their values via an `IconButton`.

### Enhancements to `SearchDialog` Component:

* Added a new `TextField` for filtering by "ID" with a placeholder example (`例: sm12345678`). Includes a clear button to reset the field. (`[manager/app/components/dialog/SearchDialog.tsxR230-R282](diffhunk://#diff-20e87f18f4802a463af256460c6ea676e907968c506fa5ebdab24fde95c8ab88R230-R282)`)
* Added a new `TextField` for filtering by "タイトル" (Title) with a placeholder example (`例: 初音ミクの歌`). Includes a clear button to reset the field. (`[manager/app/components/dialog/SearchDialog.tsxR230-R282](diffhunk://#diff-20e87f18f4802a463af256460c6ea676e907968c506fa5ebdab24fde95c8ab88R230-R282)`)