### PR TITLE
Fix issue #138: [Manager] マイリストの削除と登録処理のエンドポイント分離

### DIFF
--- a/manager/app/interface/IRegisterRequest.ts
+++ b/manager/app/interface/IRegisterRequest.ts
@@ -4,4 +4,6 @@ export interface IRegisterRequest {
   id_list: string[];
   subscription?: PushSubscription | null;
   title?: string;
+  action?: "delete" | "register";
+
 }

--- a/manager/tests/register.test.ts
+++ b/manager/tests/register.test.ts
@@ -9,10 +9,77 @@ process.env.SHARED_SECRET_KEY = 'dGVzdC1zZWNyZXQta2V5LTMyLWJ5dGVzLWxvbmc=';
 // Mock fetch
 global.fetch = jest.fn();
 
+// Mock environment variables
+process.env.REGISTER_LAMBDA_ENDPOINT = 'http://mock-lambda-endpoint';
+process.env.DELETE_LAMBDA_ENDPOINT = 'http://mock-delete-lambda-endpoint';
+process.env.SHARED_SECRET_KEY = 'dGVzdC1zZWNyZXQta2V5LTMyLWJ5dGVzLWxvbmc=';
+
 describe('POST /api/register', () => {
   beforeEach(() => {
     (fetch as jest.Mock).mockClear();
   });
+
+describe('POST /api/register', () => {
+  beforeEach(() => {
+    (global.fetch as jest.Mock).mockClear();
+  });
+
+  it('should handle registration request with successful warmup', async () => {
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ message: "Lambda is ready", timestamp: 1000 })
+      })
+      .mockResolvedValueOnce({ ok: true });
+
+    const mockRequest = {
+      json: async () => ({
+        email: 'test@example.com',
+        password: 'testpassword',
+        id_list: ['sm12345'],
+        subscription: null,
+        action: 'register'
+      })
+    } as NextRequest;
+
+    const response = await POST(mockRequest);
+    const data = await response.json();
+
+    expect(response.status).toBe(202);
+    expect(data.message).toBe('register処理を開始しました。完了時に通知をお送りします。');
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+}
+
+// Add tests for delete action
+
+describe('POST /api/register with delete action', () => {
+  it('should handle delete request with successful warmup', async () => {
+    (fetch as jest.Mock)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ message: "Lambda is ready", timestamp: 1000 })
+      })
+      .mockResolvedValueOnce({ ok: true });
+
+    const mockRequest = {
+      json: async () => ({
+        email: 'test@example.com',
+        password: 'testpassword',
+        id_list: ['sm12345'],
+        subscription: null,
+        action: 'delete'
+      })
+    } as NextRequest;
+
+    const response = await POST(mockRequest);
+    const data = await response.json();
+
+    expect(response.status).toBe(202);
+    expect(data.message).toBe('delete処理を開始しました。完了時に通知をお送りします。');
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+});
 
   it('should handle registration request with successful warmup', async () => {
     // Mock successful warmup and registration requests
@@ -28,6 +95,38 @@ describe('POST /api/register', () => {
         email: 'test@example.com',
         password: 'testpassword',
         id_list: ['sm12345'],
+import { NextRequest } from 'next/server';
+
+// Add tests for delete action
+
+describe('POST /api/register with delete action', () => {
+  it('should handle delete request with successful warmup', async () => {
+    (fetch as jest.Mock)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ message: "Lambda is ready", timestamp: 1000 })
+      }) // warmup request
+      .mockResolvedValueOnce({ ok: true }); // actual request
+
+    const mockRequest = {
+      json: async () => ({
+        email: 'test@example.com',
+        password: 'testpassword',
+        id_list: ['sm12345'],
+        subscription: null,
+        action: 'delete'
+      })
+    } as NextRequest;
+
+    const response = await POST(mockRequest);
+    const data = await response.json();
+
+    expect(response.status).toBe(202);
+    expect(data.message).toBe('delete処理を開始しました。完了時に通知をお送りします。');
+    expect(fetch).toHaveBeenCalledTimes(2); // warmup + actual
+  });
+});
+
         subscription: null
       })
     } as NextRequest;


### PR DESCRIPTION
This pull request introduces support for handling both "register" and "delete" actions in the registration API. The changes include updates to the API logic, interface definitions, and test cases to accommodate the new functionality.

### API Enhancements:
* [`manager/app/api/register/route.ts`](diffhunk://#diff-e63c575318a9ccf5a79206ef51697df4cfa96a0eae244697d5c9a92c1b67eb35L50-R68): Updated the `POST` method to dynamically switch Lambda endpoints based on the `action` parameter (`delete` or `register`). Adjusted warmup logic and response messages accordingly. [[1]](diffhunk://#diff-e63c575318a9ccf5a79206ef51697df4cfa96a0eae244697d5c9a92c1b67eb35L50-R68) [[2]](diffhunk://#diff-e63c575318a9ccf5a79206ef51697df4cfa96a0eae244697d5c9a92c1b67eb35L79-R80)

### Interface Updates:
* [`manager/app/interface/IRegisterRequest.ts`](diffhunk://#diff-468fe7bfcc79f8367a7aebdf932c3aab6d09976f076fd96a8891c4154df54408R7-R8): Added an optional `action` field to the `IRegisterRequest` interface to specify the type of operation (`"delete"` or `"register"`).

### Test Coverage:
* [`manager/tests/register.test.ts`](diffhunk://#diff-e35b828e57f8ceb818ba8e5f65bcaf9b56ebf203a425f258658b2fed517e3bfaR12-R83): Enhanced test cases to include scenarios for both "register" and "delete" actions. Mocked environment variables for Lambda endpoints and validated API behavior. [[1]](diffhunk://#diff-e35b828e57f8ceb818ba8e5f65bcaf9b56ebf203a425f258658b2fed517e3bfaR12-R83) [[2]](diffhunk://#diff-e35b828e57f8ceb818ba8e5f65bcaf9b56ebf203a425f258658b2fed517e3bfaR98-R129)