### PR TITLE
v1.6.3

### DIFF
--- a/manager/app/api/register/route.ts
+++ b/manager/app/api/register/route.ts
@@ -8,10 +8,13 @@ export async function POST(req: NextRequest) {
 
     const client = new BatchClient({ region: process.env.AWS_REGION });
 
+    // 環境判別は DynamoDB のテーブル名で行っているが、いずれは別の方法に変更する
+    const isDev = process.env.DYNAMO_TABLE_NAME?.includes('Dev');
+
     const params: SubmitJobCommandInput = {
         jobName: `register-batch-job-${Date.now()}`,
-        jobQueue: 'dev-niconico-mylist-assistant-register-batch-queue',
-        jobDefinition: 'dev-niconico-mylist-assistant-register-batch-jobdef',
+        jobQueue: isDev ? 'dev-niconico-mylist-assistant-register-batch-queue' : 'niconico-mylist-assistant-register-batch-queue',
+        jobDefinition: isDev ? 'dev-niconico-mylist-assistant-register-batch-jobdef' : 'niconico-mylist-assistant-register-batch-jobdef',
         containerOverrides: {
             environment: [
                 { name: 'NICONICO_EMAIL', value: email },

--- a/register-batch/aws/batch.yaml
+++ b/register-batch/aws/batch.yaml
@@ -122,5 +122,5 @@ Resources:
       RetryStrategy:
         Attempts: 1
       Timeout:
-        AttemptDurationSeconds: 600
+        AttemptDurationSeconds: 900
       JobDefinitionName: niconico-mylist-assistant-register-batch-jobdef

--- a/register-batch/aws/dev-batch.yaml
+++ b/register-batch/aws/dev-batch.yaml
@@ -122,5 +122,5 @@ Resources:
       RetryStrategy:
         Attempts: 1
       Timeout:
-        AttemptDurationSeconds: 600
+        AttemptDurationSeconds: 900
       JobDefinitionName: dev-niconico-mylist-assistant-register-batch-jobdef


### PR DESCRIPTION
This pull request introduces improvements to environment detection for AWS Batch job submission and increases the timeout duration for batch jobs in both development and production environments. The main changes focus on making environment selection more robust and ensuring jobs have sufficient time to complete.

**Environment detection and job configuration:**

* Updated `manager/app/api/register/route.ts` to determine the environment (development or production) based on the DynamoDB table name, and set the appropriate Batch job queue and job definition accordingly.

**Batch job timeout adjustments:**

* Increased `AttemptDurationSeconds` from 600 to 900 seconds for the production job definition in `register-batch/aws/batch.yaml`.
* Increased `AttemptDurationSeconds` from 600 to 900 seconds for the development job definition in `register-batch/aws/dev-batch.yaml`.